### PR TITLE
Avoid marking columns in composite keys unique or primary.

### DIFF
--- a/lib/MwbExporter/Model/Index.php
+++ b/lib/MwbExporter/Model/Index.php
@@ -43,18 +43,24 @@ class Index extends Base
         }
         // check for primary columns, to notify column
         $nodes = $this->node->xpath("value[@key='columns']/value/link[@key='referencedColumn']");
+        $isSingle = count($nodes) == 1;
         foreach ($nodes as $node) {
             // for primary indexes ignore external index
             // definition and set column to primary instead
             if (!($column = $this->getDocument()->getReference()->get((string) $node))) {
                 continue;
             }
-            if ($this->isPrimary()) {
-                $column->markAsPrimary();
+
+            if ($isSingle) {
+                // Columns in composite keys should not be marked primary or unique
+                if ($this->isPrimary()) {
+                    $column->markAsPrimary();
+                }
+                if ($this->isUnique()) {
+                    $column->markAsUnique();
+                }
             }
-            if ($this->isUnique()) {
-                $column->markAsUnique();
-            }
+
             $this->columns[] = $column;
         }
         if (!$this->isPrimary() && ($table = $this->getDocument()->getReference()->get((string) $this->node->link))) {


### PR DESCRIPTION
Previously columns in a composite key (e.g. KEY
`my_compound_key` (`columnA`,`columnB`)) would have a composite key
generated for them but would *also* have each individual column marked
as unique; this obviously causes problems when trying to insert into the
table.

While fixing this, I noticed that the same issue would occur for primary
keys so I have also avoided marking these as primary if they are part of
a composite key.