### PR TITLE
Made relatedName (relatedBy%foreignCol%) configurable for Doctrine2 outp...

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Formatter.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Formatter.php
@@ -37,6 +37,7 @@ abstract class Formatter extends BaseFormatter
     const CFG_REPOSITORY_NAMESPACE           = 'repositoryNamespace';
     const CFG_AUTOMATIC_REPOSITORY           = 'useAutomaticRepository';
     const CFG_SKIP_COLUMN_WITH_RELATION      = 'skipColumnWithRelation';
+    const CFG_RELATED_NAME_FORMAT            = 'relatedNameFormat';
     const CFG_RELATED_VAR_NAME_FORMAT        = 'relatedVarNameFormat';
     const CFG_NULLABLE_ATTRIBUTE             = 'nullableAttribute';
 
@@ -52,6 +53,7 @@ abstract class Formatter extends BaseFormatter
             static::CFG_REPOSITORY_NAMESPACE          => '',
             static::CFG_AUTOMATIC_REPOSITORY          => true,
             static::CFG_SKIP_COLUMN_WITH_RELATION     => false,
+            static::CFG_RELATED_NAME_FORMAT           => 'RelatedBy%foreignCol%',
             static::CFG_RELATED_VAR_NAME_FORMAT       => '%name%%related%',
             static::CFG_NULLABLE_ATTRIBUTE            => static::NULLABLE_AUTO,
         ));

--- a/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Model/Table.php
@@ -117,4 +117,23 @@ class Table extends BaseTable
 
         return $plural ? Inflector::pluralize($name) : $name;
     }
+
+    /**
+     * Format column name as relation to foreign table.
+     *
+     * @param string $column  The column name
+     * @param bool   $code    If true, use result as PHP code or false, use as comment
+     * @return string
+     */
+    public function formatRelatedName($column, $code = true)
+    {
+        if($code) {
+            $format = $this->getConfig()->get(Formatter::CFG_RELATED_NAME_FORMAT);
+            $column = $this->beautify($column);
+        } else {
+            $format = 'related by `%foreignCol%`';
+        }
+
+        return strtr($format, array('%foreignCol%' => $column));
+    }
 }


### PR DESCRIPTION
Made the relatedName ("RelatedBy%foreignCol%") configurable for Doctrine2 output, because I wanted:

$product->getFeatures();

instead of

$product->getRelatedByFeatures();