### PR TITLE
Map datetime to \DateTime

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/DatatypeConverter.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/DatatypeConverter.php
@@ -98,11 +98,14 @@ class DatatypeConverter extends BaseDatatypeConverter
         switch ($type) {
             case 'array':
             case 'boolean':
-            case 'datetime':
             case 'integer':
             case 'string':
             case 'float':
             case 'object':
+                break;
+
+            case 'datetime':
+                return '\\DateTime';
                 break;
 
             case 'smallint':

--- a/lib/MwbExporter/Formatter/Doctrine2/DatatypeConverter.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/DatatypeConverter.php
@@ -105,18 +105,15 @@ class DatatypeConverter extends BaseDatatypeConverter
                 break;
 
             case 'datetime':
+            case 'datetimez':
+            case 'date':
+            case 'time':
                 return '\\DateTime';
                 break;
 
             case 'smallint':
             case 'bigint':
                 $type = 'integer';
-                break;
-
-            case 'datetimez':
-            case 'date':
-            case 'time':
-                $type = 'datetime';
                 break;
 
             case 'decimal':


### PR DESCRIPTION
Mapping `datetime` to its correct form - `\DateTime`