### PR TITLE
Fix --list-exporter option.

### DIFF
--- a/bin/mysql-workbench-schema-export
+++ b/bin/mysql-workbench-schema-export
@@ -233,6 +233,14 @@ function main($filename, $dir, $params, $options)
     try {
         showTitle();
 
+        // bootstrap
+        $bootstrap = new Bootstrap();
+        if ($options[CMD_OPT_LIST_EXPORTER]) {
+            echo "Supported exporter:\n";
+            listFormatter($bootstrap, true);
+            die(0);
+        }
+
         // check the existance of filename
         if (!is_readable($filename)) {
             echo sprintf("Can't find document %s.\n\n", $filename);
@@ -241,14 +249,6 @@ function main($filename, $dir, $params, $options)
 
         $setup = array();
         $configs = array();
-
-        // bootstrap
-        $bootstrap = new Bootstrap();
-        if ($options[CMD_OPT_LIST_EXPORTER]) {
-            echo "Supported exporter:\n";
-            listFormatter($bootstrap, true);
-            die(0);
-        }
 
         // lookup config file export.json
         if (!$options[CMD_OPT_NO_AUTO_CONFIG] && !$params[CMD_PARAM_CONFIG]) {


### PR DESCRIPTION
The --list-exporter option needed to be moved before the $filename check to run.  Otherwise, you get a **"Can't find document ."** returned.