### PR TITLE
User Defined Type support.

### DIFF
--- a/bin/mysql-workbench-schema-export
+++ b/bin/mysql-workbench-schema-export
@@ -335,7 +335,6 @@ function main($filename, $dir, $params, $options)
     } else {
         throw new Exception("Export failed, may be there is no storage available.");
     }
-
 }
 
 // ----------------------------------------- MAIN ---------------------------------------------------- //
@@ -368,4 +367,5 @@ try {
     echo $e->getMessage();
     die(1);
 }
+
 // ----------------------------------------- EOF ----------------------------------------------------- //

--- a/bin/mysql-workbench-schema-export
+++ b/bin/mysql-workbench-schema-export
@@ -107,8 +107,7 @@ function parseCmdLine($args = array(), &$params = array(), &$options = array(), 
                 }
             }
             if (!$found) {
-                echo sprintf("Unknown option %s.\n", $arg);
-                die(1);
+                throw new InvalidArgumentException(sprintf("Unknown option %s.\n", $arg));
             }
         } else {
             $values[] = $arg;
@@ -230,147 +229,143 @@ function chooseFormatter($bootstrap)
 
 function main($filename, $dir, $params, $options)
 {
-    try {
-        showTitle();
+    showTitle();
 
-        // bootstrap
-        $bootstrap = new Bootstrap();
-        if ($options[CMD_OPT_LIST_EXPORTER]) {
-            echo "Supported exporter:\n";
-            listFormatter($bootstrap, true);
-            die(0);
-        }
-
-        // check the existance of filename
-        if (!is_readable($filename)) {
-            echo sprintf("Can't find document %s.\n\n", $filename);
-            die(1);
-        }
-
-        $setup = array();
-        $configs = array();
-
-        // lookup config file export.json
-        if (!$options[CMD_OPT_NO_AUTO_CONFIG] && !$params[CMD_PARAM_CONFIG]) {
-            $config = getcwd().DIRECTORY_SEPARATOR.'export.json';
-            if (is_readable($config)) {
-                $params[CMD_PARAM_CONFIG] = $config;
-            }
-        }
-
-        // check config file
-        if ($config = $params[CMD_PARAM_CONFIG]) {
-            if (!is_readable($config)) {
-                echo sprintf("Can't read config file %s, using interactive mode.\n\n", $config);
-            } else {
-                if (null !== ($data = json_decode(file_get_contents($config), true))) {
-                    echo sprintf("Using config file %s for parameters.\n\n", $config);
-                    if (isset($data[CMD_PARAM_EXPORT])) {
-                        $params[CMD_PARAM_EXPORT] = $data[CMD_PARAM_EXPORT];
-                    }
-                    if (isset($data[CMD_OPT_ZIP])) {
-                        $options[CMD_OPT_ZIP] = (bool) $data[CMD_OPT_ZIP];
-                    }
-                    if (isset($data['dir'])) {
-                        $dir = $data['dir'];
-                    }
-                    if (isset($data['params'])) {
-                        $configs = $data['params'];
-                    }
-                } else {
-                    echo sprintf("Ignoring invalid config file %s.\n\n", $config);
-                }
-            }
-        }
-
-        // choose exporter to use if not specified
-        if (null === $params[CMD_PARAM_EXPORT]) {
-            // choose exporter to use
-            echo "Choose which exporter to use:\n";
-            $params[CMD_PARAM_EXPORT] = chooseFormatter($bootstrap);
-            echo "\n";
-        }
-
-        // get formatter after getting the parameter export either from command line or config file
-        if (!$formatter = $bootstrap->getFormatter($params[CMD_PARAM_EXPORT])) {
-            echo sprintf("Unsupported exporter %s. Use --%s option to show all available exporter.", $params[CMD_PARAM_EXPORT], CMD_OPT_LIST_EXPORTER);
-            die(1);
-        }
-
-        // parameters customization
-        echo sprintf("Exporting %s as %s.\n\n", basename($filename), $formatter->getTitle());
-        $setup = $formatter->getConfigurations();
-        if (count($configs)) {
-            mergeFormatter($setup, $configs);
-        } else {
-            $ask = false;
-            askValue('Would you like to change the setup configuration before exporting', $ask);
-            if ($ask) {
-                setupFormatter($setup, $formatter->getValidators());
-            }
-            echo "\n";
-        }
-
-        // save export parameters
-        if ($options[CMD_OPT_SAVE_CONFIG]) {
-            file_put_contents('export.json', json_encode(
-                array(
-                    CMD_PARAM_EXPORT => $params[CMD_PARAM_EXPORT], 
-                    CMD_OPT_ZIP => $options[CMD_OPT_ZIP], 
-                    'dir' => $dir, 'params' => $setup
-                )
-            ));
-        }
-
-        // start time
-        $start = microtime(true);
-
-        // parse the mwb file
-        $formatter->setup($setup);
-        $document = $bootstrap->export($formatter, $filename, $dir, $options[CMD_OPT_ZIP] ? 'zip' : 'file');
-
-        // end time
-        $end = microtime(true);
-
-        if ($document) {
-            echo sprintf("File exported to %s.\n\n", $document->getWriter()->getStorage()->getResult());
-            // show some information about used memory
-            // show the time needed to parse the mwb file
-            echo sprintf("Done in %0.3f second, %0.3f MB memory used.\n", $end - $start, memory_get_peak_usage(true) / 1024 / 1024);
-            die(0);
-        } else {
-            echo "Export failed, may be there is no storage available.\n\n";
-            die(1);
-        }
-    } catch (\Exception $e) {
-        echo "Error:\n";
-        echo $e->getMessage();
-        die(1);
+    // bootstrap
+    $bootstrap = new Bootstrap();
+    if ($options[CMD_OPT_LIST_EXPORTER]) {
+        echo "Supported exporter:\n";
+        listFormatter($bootstrap, true);
+        die(0);
     }
+
+    // check the existance of filename
+    if (!is_readable($filename)) {
+        throw new \InvalidArgumentException(sprintf("Can't find document %s.\n\n", $filename));
+    }
+
+    $setup = array();
+    $configs = array();
+
+    // lookup config file export.json
+    if (!$options[CMD_OPT_NO_AUTO_CONFIG] && !$params[CMD_PARAM_CONFIG]) {
+        $config = getcwd().DIRECTORY_SEPARATOR.'export.json';
+        if (is_readable($config)) {
+            $params[CMD_PARAM_CONFIG] = $config;
+        }
+    }
+
+    // check config file
+    if ($config = $params[CMD_PARAM_CONFIG]) {
+        if (!is_readable($config)) {
+            echo sprintf("Can't read config file %s, using interactive mode.\n\n", $config);
+        } elseif (null !== ($data = json_decode(file_get_contents($config), true))) {
+            echo sprintf("Using config file %s for parameters.\n\n", $config);
+            if (isset($data[CMD_PARAM_EXPORT])) {
+                $params[CMD_PARAM_EXPORT] = $data[CMD_PARAM_EXPORT];
+            }
+            if (isset($data[CMD_OPT_ZIP])) {
+                $options[CMD_OPT_ZIP] = (bool) $data[CMD_OPT_ZIP];
+            }
+            if (isset($data['dir'])) {
+                $dir = $data['dir'];
+            }
+            if (isset($data['params'])) {
+                $configs = $data['params'];
+            }
+        } else {
+            echo sprintf("Ignoring invalid config file %s.\n\n", $config);
+        }
+    }
+
+    // choose exporter to use if not specified
+    if (null === $params[CMD_PARAM_EXPORT]) {
+        // choose exporter to use
+        echo "Choose which exporter to use:\n";
+        $params[CMD_PARAM_EXPORT] = chooseFormatter($bootstrap);
+        echo "\n";
+    }
+
+    // get formatter after getting the parameter export either from command line or config file
+    if (!$formatter = $bootstrap->getFormatter($params[CMD_PARAM_EXPORT])) {
+        throw new \InvalidArgumentException(sprintf("Unsupported exporter %s. Use --%s option to show all available exporter.", $params[CMD_PARAM_EXPORT], CMD_OPT_LIST_EXPORTER));
+    }
+
+    // parameters customization
+    echo sprintf("Exporting %s as %s.\n\n", basename($filename), $formatter->getTitle());
+    $setup = $formatter->getConfigurations();
+    if (count($configs)) {
+        mergeFormatter($setup, $configs);
+    } else {
+        $ask = false;
+        askValue('Would you like to change the setup configuration before exporting', $ask);
+        if ($ask) {
+            setupFormatter($setup, $formatter->getValidators());
+        }
+        echo "\n";
+    }
+
+    // save export parameters
+    if ($options[CMD_OPT_SAVE_CONFIG]) {
+        file_put_contents('export.json', json_encode(
+            array(
+                CMD_PARAM_EXPORT => $params[CMD_PARAM_EXPORT],
+                CMD_OPT_ZIP => $options[CMD_OPT_ZIP],
+                'dir' => $dir, 'params' => $setup
+            )
+        ));
+    }
+
+    // start time
+    $start = microtime(true);
+
+    // parse the mwb file
+    $formatter->setup($setup);
+    $document = $bootstrap->export($formatter, $filename, $dir, $options[CMD_OPT_ZIP] ? 'zip' : 'file');
+
+    // end time
+    $end = microtime(true);
+
+    if ($document) {
+        echo sprintf("File exported to %s.\n\n", $document->getWriter()->getStorage()->getResult());
+        // show some information about used memory
+        // show the time needed to parse the mwb file
+        echo sprintf("Done in %0.3f second, %0.3f MB memory used.\n", $end - $start, memory_get_peak_usage(true) / 1024 / 1024);
+        die(0);
+    } else {
+        throw new Exception("Export failed, may be there is no storage available.");
+    }
+
 }
 
 // ----------------------------------------- MAIN ---------------------------------------------------- //
 
-// default values
-$arguments = $_SERVER['argv'];
-$options = array(
-    CMD_OPT_HELP           => false,
-    CMD_OPT_ZIP            => false,
-    CMD_OPT_SAVE_CONFIG    => false,
-    CMD_OPT_LIST_EXPORTER  => false,
-    CMD_OPT_NO_AUTO_CONFIG => false,
-);
-$params = array(
-    CMD_PARAM_EXPORT        => null,
-    CMD_PARAM_CONFIG        => null,
-);
+try {
+    // default values
+    $arguments = $_SERVER['argv'];
+    $options = array(
+        CMD_OPT_HELP           => false,
+        CMD_OPT_ZIP            => false,
+        CMD_OPT_SAVE_CONFIG    => false,
+        CMD_OPT_LIST_EXPORTER  => false,
+        CMD_OPT_NO_AUTO_CONFIG => false,
+    );
+    $params = array(
+        CMD_PARAM_EXPORT        => null,
+        CMD_PARAM_CONFIG        => null,
+    );
 
-array_shift($arguments);
-parseCmdLine($arguments, $params, $options, $values);
-if ($options[CMD_OPT_HELP] || (count($values) < 1) && !$options[CMD_OPT_LIST_EXPORTER]) {
-    usage();
+    array_shift($arguments);
+    parseCmdLine($arguments, $params, $options, $values);
+    if ($options[CMD_OPT_HELP] || (count($values) < 1) && !$options[CMD_OPT_LIST_EXPORTER]) {
+        usage();
+    }
+
+    main(count($values) ? $values[0] : null, count($values) > 1 ? $values[1] : getcwd(), $params, $options);
+
+} catch (\Exception $e) {
+    echo "Error:\n";
+    echo $e->getMessage();
+    die(1);
 }
-
-main(count($values) ? $values[0] : null, count($values) > 1 ? $values[1] : getcwd(), $params, $options);
-
 // ----------------------------------------- EOF ----------------------------------------------------- //

--- a/lib/MwbExporter/Formatter/DatatypeConverter.php
+++ b/lib/MwbExporter/Formatter/DatatypeConverter.php
@@ -75,7 +75,7 @@ abstract class DatatypeConverter implements DatatypeConverterInterface
             return $this->dataTypes[$key];
         } elseif (isset($this->userDatatypes[$key])) {
             return $this->userDatatypes[$key];
-        }else{
+        } else {
             throw new \RuntimeException(sprintf('Unknown data type "%s".', $key));
         }
     }

--- a/lib/MwbExporter/Formatter/DatatypeConverter.php
+++ b/lib/MwbExporter/Formatter/DatatypeConverter.php
@@ -31,7 +31,15 @@ use MwbExporter\Model\Column;
 
 abstract class DatatypeConverter implements DatatypeConverterInterface
 {
+    /**
+     * @var array
+     */
     protected $dataTypes = array();
+
+    /**
+     * @var array
+     */
+    protected $userDatatypes = array();
 
     /**
      * Register data types mapping.
@@ -40,6 +48,16 @@ abstract class DatatypeConverter implements DatatypeConverterInterface
     {
         if (!count($this->dataTypes)) {
             $this->dataTypes = $dataTypes;
+        }
+    }
+
+    /**
+     * @param array $dataTypes
+     */
+    public function registerUserDatatypes($dataTypes = array())
+    {
+        if (!count($this->userDatatypes)) {
+            $this->userDatatypes = $dataTypes;
         }
     }
 
@@ -53,11 +71,13 @@ abstract class DatatypeConverter implements DatatypeConverterInterface
         // check for existing datatype, and raise an exception
         // if it doesn't exist. Usefull when new data type defined
         // in the new version of MySQL Workbench
-        if (!isset($this->dataTypes[$key])) {
+        if (isset($this->dataTypes[$key])) {
+            return $this->dataTypes[$key];
+        } elseif (isset($this->userDatatypes[$key])) {
+            return $this->userDatatypes[$key];
+        }else{
             throw new \RuntimeException(sprintf('Unknown data type "%s".', $key));
         }
-
-        return $this->dataTypes[$key];
     }
 
     /**

--- a/lib/MwbExporter/Model/Document.php
+++ b/lib/MwbExporter/Model/Document.php
@@ -197,6 +197,7 @@ class Document extends Base
         $this->filename = $filename;
         $this->readXML($this->filename);
         $this->configure($this->xml->value);
+        $this->loadUserDatatypes();
         $this->parse();
     }
 
@@ -207,6 +208,16 @@ class Document extends Base
         if (false === $this->xml) {
             throw new \RuntimeException(sprintf('Can\'t load "%s", may be it not MySQL Workbench document.', $filename));
         } 
+    }
+
+    protected function loadUserDatatypes()
+    {
+        $dataTypes = array();
+        $userTypes = $this->node->xpath("//value[@key='userDatatypes']")[0];
+        foreach ($userTypes as $userType){
+            $dataTypes[(string) $userType['id']] = (string) $userType->xpath("link[@key='actualType']")[0];
+        }
+        $this->formatter->getDatatypeConverter()->registerUserDatatypes($dataTypes);
     }
 
     protected function parse()

--- a/lib/MwbExporter/Model/Document.php
+++ b/lib/MwbExporter/Model/Document.php
@@ -214,7 +214,7 @@ class Document extends Base
     {
         $dataTypes = array();
         $userTypes = $this->node->xpath("//value[@key='userDatatypes']")[0];
-        foreach ($userTypes as $userType){
+        foreach ($userTypes as $userType) {
             $dataTypes[(string) $userType['id']] = (string) $userType->xpath("link[@key='actualType']")[0];
         }
         $this->formatter->getDatatypeConverter()->registerUserDatatypes($dataTypes);

--- a/lib/MwbExporter/Model/Document.php
+++ b/lib/MwbExporter/Model/Document.php
@@ -212,12 +212,13 @@ class Document extends Base
 
     protected function loadUserDatatypes()
     {
+        $dataTypeConverter = $this->formatter->getDataTypeConverter();
         $dataTypes = array();
         $userTypes = $this->node->xpath("//value[@key='userDatatypes']")[0];
         foreach ($userTypes as $userType) {
-            $dataTypes[(string) $userType['id']] = (string) $userType->xpath("link[@key='actualType']")[0];
+            $dataTypes[(string) $userType['id']] = $dataTypeConverter->getDataType((string) $userType->xpath("link[@key='actualType']")[0]);
         }
-        $this->formatter->getDatatypeConverter()->registerUserDatatypes($dataTypes);
+        $dataTypeConverter->registerUserDatatypes($dataTypes);
     }
 
     protected function parse()


### PR DESCRIPTION
First commit is minor:
- Moved Try-Catch out of the main() function and replaced echo/die messages with thrown exceptions.
- Minor refactor on the else-if block for the "check config file" section.

Second commit fixes crashing on User Defined Types.  I believe we could also cut out all the formatter definitions like:

**const USERDATATYPE_BOOLEAN         = 'com.mysql.rdbms.mysql.userdatatype.boolean';**

for Doctrine, Propel, etc.  These are just aliases for the actual type and I haven't seen an mwb file yet that didn't have them defined.